### PR TITLE
Remove diff artifacts accidentally copy/pasted in by commit 601841d

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -384,11 +384,7 @@
     "description": "HTML - Defines an html document",
     "scope": "text.html"
     },
-<<<<<<< HEAD
-	"html5": {
-=======
     "html5": {
->>>>>>> fdf6a407c57c2ea56c5d0dfd12ce3e2584760cfa
     "prefix": "html5",
     "body": [
         "<!DOCTYPE html>",


### PR DESCRIPTION
It looks like you accidentally copy/pasted some part of a diff file into snippets/snippets.json making the JSON structure invalid -- cleaned it up.