### PR TITLE
Add meta viewport to HTML5 snippet

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -392,6 +392,7 @@
         "\t<head>",
         "\t\t<title>$2</title>",
         "\t\t<meta charset=\"UTF-8\">",
+        "\t\t<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
         "\t\t<link href=\"$3css/style.css\" rel=\"stylesheet\">",
         "\t</head>",
         "\t<body>",


### PR DESCRIPTION
Every page should have a proper viewport set to improve the mobile experience.
https://developers.google.com/web/fundamentals/design-and-ui/responsive/fundamentals/set-the-viewport?hl=en

This just includes it in the html5 snippet so developers don't have to try remember it
