### PR TITLE
Fixed #35

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -595,9 +595,7 @@
     "pre": {
     "prefix": "pre",
     "body": [
-        "<pre>",
-        "$1",
-        "</pre>"
+        "<pre>$1</pre>"
         ],
     "description": "HTML - Defines preformatted text",
     "scope": "text.html"


### PR DESCRIPTION
Due to <pre> tag will keep all space and CRLF as-is, so I removed the additional break lines.