### PR TITLE
Add Handlebars support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,11 @@
 			{
 				"language": "html",
 				"path": "./snippets/snippets.json"
-			}
+			},
+			{
+ -				"language": "handlebars",
+ -				"path": "./snippets/snippets.json"
+ -			},
 		]
 	}
 }


### PR DESCRIPTION
Adding `"*.hbs": "html"`/`"*.handlebars": "html"` to "files.associations" breaks compatibility with existing Handlebars extensions. Since Handlebars can be used as a superset of HTML this change should not be a problem.